### PR TITLE
Fix behaviour with temporary queues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This plugin supports a small amount of configuration options:
 
 * ```Port```: The port that the rabbitmq server is listening on. Defaults to ```15672```.
 
+* ```Ignore```: The queue to ignore, matching by Regex.  See example.
+
 Example Configuration
 =====================
 
@@ -44,6 +46,10 @@ LoadPlugin python
     Realm "RabbitMQ Management"
     Host "localhost"
     Port "15672"
+	<Ignore "queue">
+	  Regex "amq-gen-.*"
+	  Regex "tmp-.*"
+	</Ignore>
   </Module>
 </Plugin>
 ```


### PR DESCRIPTION
It's a common behaviour in RabbitMQ to have a temporary queue created
for the purpose of Ack messaging.

When such a short lived queue is created it can be caught by the listing
of the queues, but when the stats are fetched, the queue no longer
exists.  This cause this kind of error:

```
collectd[15267]: Error: HTTP Error 404: Object Not Found
collectd[15267]: Unhandled python exception in read callback: AttributeError: 'NoneType' object has no attribute 'get'
```

This patch prevent this from happening in two ways:
1. check that we have indeed some data back from rabbitmq before
   dispatching;
2. add the ability to remove such queue from being graphed
