### PR TITLE
Remove metrics that are no longer exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,27 +88,20 @@ For each queue in each vhost the following statistics are gathered:
 > NOTE: The ```/``` vhost name is sent as ```default```
 
 * message_stats
+    * ack
+    * ack_rate
+    * deliver
     * deliver_get
-    * deliver_get_details 
-    	* rate 
-    * get
-    * get_details
-        * rate
-    * publish
-    * publish_details
-        * rate
-    * redeliver  
-    * redeliver_details
-        * rate
+    * deliver_get_rate
+    * deliver_rate
+    * redeliver
+    * redeliver_rate
 * messages
-* messages_details 
-    * rate
+* messages_rate
 * messages_ready
-* messages_ready_details
-    * rate
+* messages_ready_rate
 * messages_unacknowledged
-* messages_unacknowledged_details
-  * rate
+* messages_unacknowledged_rate
 * memory
 * consumers
 
@@ -118,30 +111,11 @@ Exchanges
 For each exchange in each vhost the following statistics are gathered: 
 > NOTE: The ```/``` vhost name is sent as ```default```
 
-* disk_free 
-
-* disk_free_limit 
-
-* fd_total
-
-* fd_used
-
-* mem_limit 
-
-* mem_used
-
-* proc_total
-
-* proc_used 
-
-* processors
-
-* run_queue
-
-* sockets_total
-
-* sockets_used
-
+* message_stats
+    * publish_in
+    * publish_in_rate
+    * publish_out
+    * publish_out_rate
 
 Developing
 ==========

--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -11,22 +11,25 @@ run_queue       value:GAUGE:0:U
 sockets_total   value:GAUGE:0:U
 sockets_used    value:GAUGE:0:U
 
-rabbitmq_memory value:GAUGE:0:U
-rabbitmq_messages value:GAUGE:0:U
-rabbitmq_messages_ready value:GAUGE:0:U
-rabbitmq_messages_unacknowledged value:GAUGE:0:U
-rabbitmq_consumers value:GAUGE:0:U
-rabbitmq_details rate:GAUGE:0:U
+rabbitmq_consumers			value:GAUGE:0:U
+rabbitmq_memory				value:GAUGE:0:U
+rabbitmq_messages			value:GAUGE:0:U
+rabbitmq_messages_rate			value:GAUGE:0:U
+rabbitmq_messages_ready			value:GAUGE:0:U
+rabbitmq_messages_ready_rate		value:GAUGE:0:U
+rabbitmq_messages_unacknowledged	value:GAUGE:0:U
+rabbitmq_messages_unacknowledged_rate	value:GAUGE:0:U
 
-ack           value:GAUGE:0:U
-publish       value:GAUGE:0:U
-publish_in    value:GAUGE:0:U
-publish_out   value:GAUGE:0:U
-confirm       value:GAUGE:0:U
-deliver       value:GAUGE:0:U
-deliver_noack value:GAUGE:0:U
-get           value:GAUGE:0:U
-get_noack     value:GAUGE:0:U
-deliver_get   value:GAUGE:0:U
-redeliver     value:GAUGE:0:U
-return        value:GAUGE:0:U
+ack			value:GAUGE:0:U
+ack_rate		value:GAUGE:0:U
+deliver			value:GAUGE:0:U
+deliver_get		value:GAUGE:0:U
+deliver_get_rate	value:GAUGE:0:U
+deliver_rate		value:GAUGE:0:U
+publish_in		value:GAUGE:0:U
+publish_in_rate		value:GAUGE:0:U
+publish_out		value:GAUGE:0:U
+publish_out_rate	value:GAUGE:0:U
+redeliver		value:GAUGE:0:U
+redeliver_rate		value:GAUGE:0:U
+

--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -16,7 +16,7 @@ rabbitmq_messages value:GAUGE:0:U
 rabbitmq_messages_ready value:GAUGE:0:U
 rabbitmq_messages_unacknowledged value:GAUGE:0:U
 rabbitmq_consumers value:GAUGE:0:U
-rabbitmq_details avg:GAUGE:0:U avg_rate:GAUGE:0:U rate:GAUGE:0:U samples:GAUGE:0:U
+rabbitmq_details rate:GAUGE:0:U
 
 ack           value:GAUGE:0:U
 publish       value:GAUGE:0:U

--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -15,7 +15,7 @@ QUEUE_STATS = ['memory', 'messages', 'consumers']
 MESSAGE_STATS = ['ack', 'publish', 'publish_in', 'publish_out', 'confirm',
                  'deliver', 'deliver_noack', 'get', 'get_noack', 'deliver_get',
                  'redeliver', 'return']
-MESSAGE_DETAIL = ['avg', 'avg_rate', 'rate', 'sample']
+MESSAGE_DETAIL = ['rate']
 NODE_STATS = ['disk_free', 'disk_free_limit', 'fd_total',
               'fd_used', 'mem_limit', 'mem_used',
               'proc_total', 'proc_used', 'processors', 'run_queue',


### PR DESCRIPTION
"avg", "avg_rate", and, "samples" fields are no longer part of the
resulting JSON object produced by the RabbitMQ HTTP API of
"/api/queues/vhost/_queue_name_". This change will eliminate the
indexing of these metrics by collectd