### PR TITLE
Handle missing details in queues

### DIFF
--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -141,6 +141,8 @@ def dispatch_queue_metrics(queue, vhost):
                         'rabbitmq_%s' % name)
 
         details = queue.get("%s_details" % name, None)
+        if not details:
+            continue
         values = list()
         for detail in MESSAGE_DETAIL:
             values.append(details.get(detail, 0))


### PR DESCRIPTION
On older versions of RabbitMQ, some statistics may be missing (in my case, "messages_unacknowledged_details") causing the plugin to crash.