### PR TITLE
Add PrefixVhost configuration option to prefix rabbitmq vhost with …

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This plugin supports a small amount of configuration options:
 
 * ```Port```: The port that the rabbitmq server is listening on. Defaults to ```15672```.
 
+* ```PrefixVhost```: If enabled, rabbitmq vhost will be prefixed with the hostname in the metric name. Defaults to ```false```.
+
 * ```Ignore```: The queue to ignore, matching by Regex.  See example.
 
 Example Configuration
@@ -46,6 +48,7 @@ LoadPlugin python
     Realm "RabbitMQ Management"
     Host "localhost"
     Port "15672"
+    PrefixVhost true
 	<Ignore "queue">
 	  Regex "amq-gen-.*"
 	  Regex "tmp-.*"

--- a/config/collectd.conf
+++ b/config/collectd.conf
@@ -22,6 +22,7 @@ LoadPlugin python
     Realm "RabbitMQ Management"
     Host "localhost"
     Port "15672"
+    PrefixVhost true
   </Module>
 </Plugin>
 


### PR DESCRIPTION
…the hostname in the metric name.

This can solve the metric names collision in clusters when used with graphite output:
- https://github.com/NYTimes/collectd-rabbitmq/issues/15