### PR TITLE
Hack to support write_http plugin in Collectd <5.5

### DIFF
--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -108,6 +108,9 @@ def dispatch_values(values, host, plugin, plugin_instance, metric_type,
     if type_instance:
         metric.type_instance = type_instance
     metric.values = values
+    # Tiny hack to fix bug with write_http plugin in Collectd versions < 5.5.
+    # See https://github.com/phobos182/collectd-elasticsearch/issues/15 for details
+    metric.meta = {'0': True}
     metric.dispatch()
 
 


### PR DESCRIPTION
There's a bug with Collectd's write_http plugin that is present in Collectd 5.4.1 (the version distributed with Ubuntu LTS). The result is that RabbitMQ stats cannot be pushed as JSON with the write_http plugin. This affects people publishing stats to Librato.

For more detail, see the following bug reports:

https://github.com/phobos182/collectd-elasticsearch/issues/15

https://github.com/collectd/collectd/issues/716