### PR TITLE
Add missing types to types.db.custom

### DIFF
--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -38,8 +38,10 @@ deliver                 value:GAUGE:0:U
 deliver_details         value:GAUGE:0:U
 deliver_noack           value:GAUGE:0:U
 get                     value:GAUGE:0:U
+get_details             value:GAUGE:0:U
 get_noack               value:GAUGE:0:U
 deliver_get             value:GAUGE:0:U
 deliver_get_details     value:GAUGE:0:U
 redeliver               value:GAUGE:0:U
+redeliver_details       value:GAUGE:0:U
 return                  value:GAUGE:0:U


### PR DESCRIPTION
Several types were missing from the types DB. Added those that the plugin complained about when run in our RabbitMQ 3.5.4 environment.