### PR TITLE
Allow setting of connection scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,32 @@
 collectd-rabbitmq
-================= 
+=================
 
-A collected plugin, written in python, to collect statistics from RabbitMQ. Requires that the rabbitmq management plugin is installed. 
+A collected plugin, written in python, to collect statistics from RabbitMQ. Requires that the rabbitmq management plugin is installed.
 
 Installation
 ============
 
-Place the rabbitmq.py file in the plugins directory for collect. 
-Each of these statistics have thier own custom entery in collectd's type database. 
+Place the rabbitmq.py file in the plugins directory for collect.
+Each of these statistics have thier own custom entery in collectd's type database.
 To add these types run:
 
-``` cat config/types.db.custom >> /usr/share/collectd/types.db ```
+```
+cat config/types.db.custom >> /usr/share/collectd/types.db
+```
 
 
-Configuration 
+Configuration
 =============
 
 This plugin supports a small amount of configuration options:
 
-* ```Username```: The rabbitmq user. Defaults to ```guest```.
-
-* ```Password```: The rabbitmq user password. Defaults to ```guest```.
-
-* ```Realm```: The http realm for authentication. Defaults to ```RabbitMQ Management```. 
-
-* ```Host```: The hostname that the rabbitmq server running on. Defaults to ```localhost```.
-
-* ```Port```: The port that the rabbitmq server is listening on. Defaults to ```15672```.
-
-* ```Ignore```: The queue to ignore, matching by Regex.  See example.
+* `Username`: The rabbitmq user. Defaults to `guest`
+* `Password`: The rabbitmq user password. Defaults to `guest`
+* `Realm`: The http realm for authentication. Defaults to `RabbitMQ Management`
+* `Scheme`: The protocol that the rabbitmq management API is running on. Defaults to `http`
+* `Host`: The hostname that the rabbitmq server running on. Defaults to `localhost`
+* `Port`: The port that the rabbitmq server is listening on. Defaults to `15672`
+* `Ignore`: The queue to ignore, matching by Regex.  See example.
 
 Example Configuration
 =====================
@@ -46,10 +44,10 @@ LoadPlugin python
     Realm "RabbitMQ Management"
     Host "localhost"
     Port "15672"
-	<Ignore "queue">
-	  Regex "amq-gen-.*"
-	  Regex "tmp-.*"
-	</Ignore>
+    <Ignore "queue">
+      Regex "amq-gen-.*"
+      Regex "tmp-.*"
+    </Ignore>
   </Module>
 </Plugin>
 ```
@@ -60,48 +58,38 @@ Nodes
 For each node the following statistics are gathered:
 
 * disk_free_limit
-
 * fd_total
-
-* fd_used 
-
+* fd_used
 * mem_limit
-
 * mem_used
-
-* proc_total 
-
+* proc_total
 * proc_used
-
 * processors
-
 * run_queue
-
 * sockets_total
-
 * sockets_used
 
 Queues
 =======
 
-For each queue in each vhost the following statistics are gathered:
-> NOTE: The ```/``` vhost name is sent as ```default```
+For each queue in each vhost the following statistics are gathered:  
+_NOTE_: The `/` vhost name is sent as `default`
 
 * message_stats
     * deliver_get
-    * deliver_get_details 
-    	* rate 
+    * deliver_get_details
+        * rate
     * get
     * get_details
         * rate
     * publish
     * publish_details
         * rate
-    * redeliver  
+    * redeliver
     * redeliver_details
         * rate
 * messages
-* messages_details 
+* messages_details
     * rate
 * messages_ready
 * messages_ready_details
@@ -115,35 +103,24 @@ For each queue in each vhost the following statistics are gathered:
 Exchanges
 =========
 
-For each exchange in each vhost the following statistics are gathered: 
-> NOTE: The ```/``` vhost name is sent as ```default```
+For each exchange in each vhost the following statistics are gathered:  
+_NOTE_: The `/` vhost name is sent as `default`
 
-* disk_free 
-
-* disk_free_limit 
-
+* disk_free
+* disk_free_limit
 * fd_total
-
 * fd_used
-
-* mem_limit 
-
+* mem_limit
 * mem_used
-
 * proc_total
-
-* proc_used 
-
+* proc_used
 * processors
-
 * run_queue
-
 * sockets_total
-
 * sockets_used
 
 
 Developing
 ==========
 
-Whenever a new stat is to be added, it must be added to the config/types.db.custom file. 
+Whenever a new stat is to be added, it must be added to the `config/types.db.custom` file.

--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -7,7 +7,7 @@ import urllib
 import json
 import re
 
-RABBIT_API_URL = "http://{host}:{port}/api/"
+RABBIT_API_URL = "{scheme}://{host}:{port}/api/"
 
 QUEUE_MESSAGE_STATS = ['messages', 'messages_ready', 'messages_unacknowledged']
 QUEUE_STATS = ['memory', 'messages', 'consumers']
@@ -24,6 +24,7 @@ NODE_STATS = ['disk_free', 'disk_free_limit', 'fd_total',
 PLUGIN_CONFIG = {
     'username': 'guest',
     'password': 'guest',
+    'scheme': 'http',
     'host': 'localhost',
     'port': 15672,
     'realm': 'RabbitMQ Management'
@@ -45,6 +46,8 @@ def configure(config_values):
                 PLUGIN_CONFIG['username'] = config_value.values[0]
             elif config_value.key == 'Password':
                 PLUGIN_CONFIG['password'] = config_value.values[0]
+            elif config_value.key == 'Scheme':
+                PLUGIN_CONFIG['scheme'] = config_value.values[0]
             elif config_value.key == 'Host':
                 PLUGIN_CONFIG['host'] = config_value.values[0]
             elif config_value.key == 'Port':
@@ -208,7 +211,8 @@ def read(input_data=None):
     '''
 
     collectd.debug("Reading data with input = %s" % (input_data))
-    base_url = RABBIT_API_URL.format(host=PLUGIN_CONFIG['host'],
+    base_url = RABBIT_API_URL.format(scheme=PLUGIN_CONFIG['scheme'],
+                                     host=PLUGIN_CONFIG['host'],
                                      port=PLUGIN_CONFIG['port'])
 
     auth_handler = urllib2.HTTPBasicAuthHandler()


### PR DESCRIPTION
A quick fix for #17. Adds a `Scheme` config option for setting `https` for example:
```
LoadPlugin python
<Plugin python>
  ModulePath "/mnt/projects/collectd-rabbitmq/"
  Import rabbitmq
  <Module rabbitmq>
    Scheme "https"
    Host "localhost"
    Port "15671"
  </Module>
</Plugin>
```