### PR TITLE
Allow for https and no log in normal operation

### DIFF
--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -39,6 +39,7 @@ def configure(config_values):
     collectd.debug('Configuring RabbitMQ Plugin')
     data_to_ignore = dict()
 
+    scheme = 'http'
     for config_value in config_values.children:
         collectd.debug("%s = %s" % (config_value.key, config_value.values))
         if len(config_value.values) > 0:

--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -52,6 +52,8 @@ def configure(config_values):
                 port = config_value.values[0]
             elif config_value.key == 'Realm':
                 realm = config_value.values[0]
+            elif config_value.key == 'Scheme':
+                scheme = config_value.values[0]
             elif config_value.key == 'Ignore':
                 type_rmq = config_value.values[0]
                 data_to_ignore[type_rmq] = list()
@@ -63,7 +65,7 @@ def configure(config_values):
     global CONFIG  # pylint: disable=W0603
 
     AUTH = utils.Auth(username, password, realm)
-    CONN = utils.ConnectionInfo(host, port)
+    CONN = utils.ConnectionInfo(host, port, scheme)
     CONFIG = utils.Config(AUTH, CONN, data_to_ignore)
 
 

--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -36,11 +36,11 @@ def configure(config_values):
     Converts a collectd configuration into rabbitmq configuration.
     """
 
-    collectd.info('Configuring RabbitMQ Plugin')
+    collectd.debug('Configuring RabbitMQ Plugin')
     data_to_ignore = dict()
 
     for config_value in config_values.children:
-        collectd.info("%s = %s" % (config_value.key, config_value.values))
+        collectd.debug("%s = %s" % (config_value.key, config_value.values))
         if len(config_value.values) > 0:
             if config_value.key == 'Username':
                 username = config_value.values[0]
@@ -81,7 +81,7 @@ def read():
     """
     Reads and dispatches data.
     """
-    collectd.info("Reading data from rabbit and dispatching")
+    collectd.debug("Reading data from rabbit and dispatching")
     if not PLUGIN:
         collectd.warning('Plugin not ready')
         return


### PR DESCRIPTION
1. Allow for https by setting the scheme
2. The plugin should be quiet in normal operation (follow the gnu/linux principle)