### PR TITLE
report queue state: messages, messages_ready, messages_unacknowledged

### DIFF
--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -47,3 +47,7 @@ deliver_get_details     value:GAUGE:0:U
 redeliver               value:GAUGE:0:U
 redeliver_details       value:GAUGE:0:U
 return                  value:GAUGE:0:U
+
+messages                value:GAUGE:0:U
+messages_ready          value:GAUGE:0:U
+messages_unacknowledged value:GAUGE:0:U


### PR DESCRIPTION
Report the following numbers per queue:

- total number of messages
- messages in ready state
- unacknowledged messages