### PR TITLE
report overview stats

### DIFF
--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -108,8 +108,9 @@ class CollectdPlugin(object):
                   'sockets_total', 'sockets_used']
     overview_stats = {'object_totals': ['consumers', 'queues', 'exchanges',
                                         'connections', 'channels'],
-                      'message_stats': ['publish', 'ack', 'deliver_get', 'confirm',
-                                        'redeliver', 'deliver', 'deliver_no_ack'],
+                      'message_stats': ['publish', 'ack', 'deliver_get',
+                                        'confirm', 'redeliver', 'deliver',
+                                        'deliver_no_ack'],
                       'queue_totals': ['messages', 'messages_ready',
                                        'messages_unacknowledged']}
     overview_details = ['rate']
@@ -205,12 +206,13 @@ class CollectdPlugin(object):
             for stat_name in keys:
                 type_name = stat_name
                 type_name = type_name.replace('no_ack', 'noack')
-                if re.match("^(messages|consumers|queues|exchanges|channels)", stat_name) is not None:
+                valid_stats = "^(messages|consumers|queues|exchanges|channels)"
+                if re.match(valid_stats, stat_name) is not None:
                     type_name = "rabbitmq_%s" % stat_name
 
                 value = subtree.get(stat_name, 0)
-                self.dispatch_values(value, prefixed_cluster_name, "overview", subtree_name,
-                                     type_name)
+                self.dispatch_values(value, prefixed_cluster_name, "overview",
+                                     subtree_name, type_name)
 
                 details = subtree.get("%s_details" % stat_name, None)
                 if not details:
@@ -218,7 +220,8 @@ class CollectdPlugin(object):
                 detail_values = []
                 for detail in self.message_details:
                     detail_values.append(details.get(detail, 0))
-                self.dispatch_values(detail_values, prefixed_cluster_name, 'overview', subtree_name,
+                self.dispatch_values(detail_values, prefixed_cluster_name,
+                                     'overview', subtree_name,
                                      "rabbitmq_details", stat_name)
 
     def dispatch_queue_stats(self, data, vhost, plugin, plugin_instance):

--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -199,7 +199,7 @@ class CollectdPlugin(object):
         Dispatches cluster overview stats.
         """
         stats = self.rabbit.get_overview_stats()
-        cluster_name = stats['cluster_name']
+        prefixed_cluster_name = "rabbitmq_%s" % stats['cluster_name']
         for subtree_name, keys in self.overview_stats.items():
             subtree = stats.get(subtree_name, {})
             for stat_name in keys:
@@ -209,7 +209,7 @@ class CollectdPlugin(object):
                     type_name = "rabbitmq_%s" % stat_name
 
                 value = subtree.get(stat_name, 0)
-                self.dispatch_values(value, cluster_name, "overview", subtree_name,
+                self.dispatch_values(value, prefixed_cluster_name, "overview", subtree_name,
                                      type_name)
 
                 details = subtree.get("%s_details" % stat_name, None)
@@ -218,7 +218,7 @@ class CollectdPlugin(object):
                 detail_values = []
                 for detail in self.message_details:
                     detail_values.append(details.get(detail, 0))
-                self.dispatch_values(detail_values, cluster_name, 'overview', subtree_name,
+                self.dispatch_values(detail_values, prefixed_cluster_name, 'overview', subtree_name,
                                      "rabbitmq_details", stat_name)
 
     def dispatch_queue_stats(self, data, vhost, plugin, plugin_instance):

--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -106,6 +106,13 @@ class CollectdPlugin(object):
                   'fd_used', 'mem_limit', 'mem_used',
                   'proc_total', 'proc_used', 'processors', 'run_queue',
                   'sockets_total', 'sockets_used']
+    overview_stats = {'object_totals': ['consumers', 'queues', 'exchanges',
+                                        'connections', 'channels'],
+                      'message_stats': ['publish', 'ack', 'deliver_get', 'confirm',
+                                        'redeliver', 'deliver', 'deliver_no_ack'],
+                      'queue_totals': ['messages', 'messages_ready',
+                                       'messages_unacknowledged']}
+    overview_details = ['rate']
 
     def __init__(self):
         self.rabbit = rabbit.RabbitMQStats(CONFIG)
@@ -115,6 +122,7 @@ class CollectdPlugin(object):
         Dispatches values to collectd.
         """
         self.dispatch_nodes()
+        self.dispatch_overview()
         for vhost_name in self.rabbit.vhost_names:
             self.dispatch_exchanges(vhost_name)
             self.dispatch_queues(vhost_name)
@@ -185,6 +193,33 @@ class CollectdPlugin(object):
                     value = details.get(detail, 0)
                     self.dispatch_values(value, name, 'rabbitmq', None,
                                          "%s_details" % stat_name, detail)
+
+    def dispatch_overview(self):
+        """
+        Dispatches cluster overview stats.
+        """
+        stats = self.rabbit.get_overview_stats()
+        cluster_name = stats['cluster_name']
+        for subtree_name, keys in self.overview_stats.items():
+            subtree = stats.get(subtree_name, {})
+            for stat_name in keys:
+                type_name = stat_name
+                type_name = type_name.replace('no_ack', 'noack')
+                if re.match("^(messages|consumers|queues|exchanges|channels)", stat_name) is not None:
+                    type_name = "rabbitmq_%s" % stat_name
+
+                value = subtree.get(stat_name, 0)
+                self.dispatch_values(value, cluster_name, "overview", subtree_name,
+                                     type_name)
+
+                details = subtree.get("%s_details" % stat_name, None)
+                if not details:
+                    continue
+                detail_values = []
+                for detail in self.message_details:
+                    detail_values.append(details.get(detail, 0))
+                self.dispatch_values(detail_values, cluster_name, 'overview', subtree_name,
+                                     "rabbitmq_details", stat_name)
 
     def dispatch_queue_stats(self, data, vhost, plugin, plugin_instance):
         """

--- a/collectd_rabbitmq/rabbit.py
+++ b/collectd_rabbitmq/rabbit.py
@@ -156,6 +156,12 @@ class RabbitMQStats(object):
         """
         return self.get_stats('queue', queue_name, vhost_name)
 
+    def get_overview_stats(self):
+        """
+        Returns a dictionary of cluster/node-wide stats.
+        """
+        return self.get_info("overview")
+
     def get_stats(self, stat_type, stat_name, vhost_name):
         """
         Returns a dictionary of stats.

--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -21,9 +21,10 @@ rabbitmq_messages                value:GAUGE:0:U
 rabbitmq_messages_ready          value:GAUGE:0:U
 rabbitmq_messages_unacknowledged value:GAUGE:0:U
 rabbitmq_consumers               value:GAUGE:0:U
+rabbitmq_exchanges               value:GAUGE:0:U
+rabbitmq_channels                value:GAUGE:0:U
+rabbitmq_queues                  value:GAUGE:0:U
 rabbitmq_details                 avg:GAUGE:0:U avg_rate:GAUGE:0:U rate:GAUGE:0:U samples:GAUGE:0:U
-rabbitmq_consumers value:GAUGE:0:U
-rabbitmq_details avg:GAUGE:0:U, avg_rate:GAUGE:0:U, rate:GAUGE:0:U, samples:GAUGE:0:U
 
 ack                 value:GAUGE:0:U
 ack_details         value:GAUGE:0:U

--- a/tests/test_collectd_plugin.py
+++ b/tests/test_collectd_plugin.py
@@ -335,13 +335,16 @@ class TestCollectdPluginRead(BaseTestCollectdPlugin):
         dispatch_nodes = MagicMock()
         dispatch_queues = MagicMock()
         dispatch_exchanges = MagicMock()
+        dispatch_overview = MagicMock()
         self.collectd_plugin.dispatch_nodes = dispatch_nodes
         self.collectd_plugin.dispatch_queues = dispatch_queues
         self.collectd_plugin.dispatch_exchanges = dispatch_exchanges
+        self.collectd_plugin.dispatch_overview = dispatch_overview
 
         self.collectd_plugin.read()
 
         self.assertTrue(dispatch_nodes.called)
+        self.assertTrue(dispatch_overview.called)
         self.assertTrue(dispatch_queues.called)
         self.assertTrue(dispatch_exchanges.called)
 
@@ -353,13 +356,16 @@ class TestCollectdPluginRead(BaseTestCollectdPlugin):
         dispatch_nodes = MagicMock()
         dispatch_queues = MagicMock()
         dispatch_exchanges = MagicMock()
+        dispatch_overview = MagicMock()
         self.collectd_plugin.dispatch_nodes = dispatch_nodes
         self.collectd_plugin.dispatch_queues = dispatch_queues
         self.collectd_plugin.dispatch_exchanges = dispatch_exchanges
+        self.collectd_plugin.dispatch_overview = dispatch_overview
 
         self.collectd_plugin.read()
 
         self.assertTrue(dispatch_nodes.called)
+        self.assertTrue(dispatch_overview.called)
         self.assertFalse(dispatch_queues.called)
         self.assertFalse(dispatch_exchanges.called)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -51,7 +51,7 @@ def get_node_stats_data():
         "disk_free": 20234559488,
         "disk_free_details": {
             "rate": -27852.799999999999
-        },
+            },
         "disk_free_limit": 50000000,
 
         "fd_total": 150000,


### PR DESCRIPTION
N.B. - I don't even pretend to be a Python programmer, so I am likely doing dumb things.  Needless to say, feedback is welcome.

This scratches my itch for getting overview stats about our rabbitmq cluster.  I'm motivated by the fact that we use quite a lot of topic queues which aren't visible in the queue list (a good thing), so queue-level stats miss a lot of the traffic.