### PR TITLE
Feature/multiple endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Pycharm/Intellij Idea
+.idea


### PR DESCRIPTION
Example:

```
LoadPlugin python

<Plugin python>
  LogTraces true
  Interactive false
  Import "collectd_rabbitmq.collectd_plugin"

  <Module "collectd_rabbitmq.collectd_plugin">
    VHostPrefix "prefix1"
    Username "guest"
    Password "guest"
    Realm "RabbitMQ Management"
    Host "localhost"
    Port "15672"
  </Module>

  <Module "collectd_rabbitmq.collectd_plugin">
    VHostPrefix "prefix2"
    Username "guest"
    Password "guest"
    Realm "RabbitMQ Management"
    Host "localhost"
    Port "15673"
  </Module>
</Plugin>
```
