### PR TITLE
Use rabbitmq_connections for the connections overview stat

### DIFF
--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -206,8 +206,10 @@ class CollectdPlugin(object):
             for stat_name in keys:
                 type_name = stat_name
                 type_name = type_name.replace('no_ack', 'noack')
-                valid_stats = "^(messages|consumers|queues|exchanges|channels)"
-                if re.match(valid_stats, stat_name) is not None:
+                stats_re = re.compile(r"""
+                    ^(connections|messages|consumers|queues|exchanges|channels)
+                    """, re.X)
+                if re.match(stats_re, stat_name) is not None:
                     type_name = "rabbitmq_%s" % stat_name
 
                 value = subtree.get(stat_name, 0)

--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -20,6 +20,7 @@ rabbitmq_memory                  value:GAUGE:0:U
 rabbitmq_messages                value:GAUGE:0:U
 rabbitmq_messages_ready          value:GAUGE:0:U
 rabbitmq_messages_unacknowledged value:GAUGE:0:U
+rabbitmq_connections             value:GAUGE:0:U
 rabbitmq_consumers               value:GAUGE:0:U
 rabbitmq_exchanges               value:GAUGE:0:U
 rabbitmq_channels                value:GAUGE:0:U


### PR DESCRIPTION
This changes the cluster connections overview stat to use the `rabbitmq_connections` type, since we want a gauge and the default `connections` type is a derive type.

Missed this in the initial PR...