### PR TITLE
collectd_plugin.py : fix exception when rabbitmq server is unreachable

### DIFF
--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -200,6 +200,8 @@ class CollectdPlugin(object):
         Dispatches cluster overview stats.
         """
         stats = self.rabbit.get_overview_stats()
+        if stats is None:
+            return None
         prefixed_cluster_name = "rabbitmq_%s" % stats['cluster_name']
         for subtree_name, keys in self.overview_stats.items():
             subtree = stats.get(subtree_name, {})


### PR DESCRIPTION
Hi,

This is a small fix to avoid the following exception when rabbitmq is unreachable.
```
Jul 19 12:08:11 app-1 collectd[26893]: URL Error: <urlopen error [Errno 111] Connection refused>
Jul 19 12:08:11 app-1 collectd[26893]: URL Error: <urlopen error [Errno 111] Connection refused>
Jul 19 12:08:11 app-1 collectd[26893]: Unhandled python exception in read callback: TypeError: 'NoneType' object has no attribute '__getitem__'
Jul 19 12:08:11 app-1 collectd[26893]: Traceback (most recent call last):
Jul 19 12:08:11 app-1 collectd[26893]:   File "/usr/local/lib/python2.7/dist-packages/collectd_rabbitmq-1.10.0-py2.7.egg/collectd_rabbitmq/collectd_plugin.py"
, line 93, in read#012    PLUGIN.read()
Jul 19 12:08:11 app-1 collectd[26893]:   File "/usr/local/lib/python2.7/dist-packages/collectd_rabbitmq-1.10.0-py2.7.egg/collectd_rabbitmq/collectd_plugin.py"
, line 126, in read#012    self.dispatch_overview()
Jul 19 12:08:11 app-1 collectd[26893]:   File "/usr/local/lib/python2.7/dist-packages/collectd_rabbitmq-1.10.0-py2.7.egg/collectd_rabbitmq/collectd_plugin.py"
, line 203, in dispatch_overview#012    prefixed_cluster_name = "rabbitmq_%s" % stats['cluster_name']
Jul 19 12:08:11 app-1 collectd[26893]: TypeError: 'NoneType' object has no attribute '__getitem__'
Jul 19 12:08:11 app-1 collectd[26893]: read-function of plugin `python.collectd_rabbitmq.collectd_plugin' failed. Will suspend it for 20.000 seconds.

```