### PR TITLE
add consumers to queue stats

### DIFF
--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -101,7 +101,8 @@ class CollectdPlugin(object):
                      'deliver', 'deliver_noack', 'get', 'get_noack',
                      'deliver_get', 'redeliver', 'return']
     message_details = ['avg', 'avg_rate', 'rate', 'sample']
-    queue_stats = ['messages', 'messages_ready', 'messages_unacknowledged']
+    queue_stats = ['consumers', 'messages', 'messages_ready',
+                   'messages_unacknowledged']
     node_stats = ['disk_free', 'disk_free_limit', 'fd_total',
                   'fd_used', 'mem_limit', 'mem_used',
                   'proc_total', 'proc_used', 'processors', 'run_queue',


### PR DESCRIPTION
Noticed that I wasn't getting consumers value for each queue. Based on the readme I thought it should be there. Added it in, tests all pass, getting the stats in prod using this patch so it seems to be working fine.
