### PR TITLE
Docs: Use correct module name in example

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,4 +4,4 @@ Usage
 
 To use collectd-rabbitmq in a project::
 
-    import collectd-rabbitmq
+    import collectd_rabbitmq


### PR DESCRIPTION
While the package is named collectd-rabbitmq the Python module that can be imported is named collectd_rabbitmq.