### PR TITLE
Fix - plugin crash when metric is not in collectd types db

### DIFF
--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -304,29 +304,33 @@ class CollectdPlugin(object):
 
         collectd.debug("Dispatching %s values: %s" % (path, values))
 
-        metric = collectd.Values()
-        metric.host = host
+        try:
+            metric = collectd.Values()
+            metric.host = host
 
-        metric.plugin = plugin
+            metric.plugin = plugin
 
-        if plugin_instance:
-            metric.plugin_instance = plugin_instance
+            if plugin_instance:
+                metric.plugin_instance = plugin_instance
 
-        metric.type = metric_type
+            metric.type = metric_type
 
-        if type_instance:
-            metric.type_instance = type_instance
+            if type_instance:
+                metric.type_instance = type_instance
 
-        if utils.is_sequence(values):
-            metric.values = values
-        else:
-            metric.values = [values]
-        # Tiny hack to fix bug with write_http plugin in Collectd
-        # versions < 5.5.
-        # See https://github.com/phobos182/collectd-elasticsearch/issues/15
-        # for details
-        metric.meta = {'0': True}
-        metric.dispatch()
+            if utils.is_sequence(values):
+                metric.values = values
+            else:
+                metric.values = [values]
+            # Tiny hack to fix bug with write_http plugin in Collectd
+            # versions < 5.5.
+            # See https://github.com/phobos182/collectd-elasticsearch/issues/15
+            # for details
+            metric.meta = {'0': True}
+            metric.dispatch()
+        except Exception as ex:
+            collectd.warning("Failed to dispatch %s. Exception %s" %
+                             (path, ex))
 
 
 # Register callbacks

--- a/tests/test_collectd_plugin.py
+++ b/tests/test_collectd_plugin.py
@@ -578,6 +578,20 @@ class TestCollectdPluginDispatch(BaseTestCollectdPlugin):
         self.assertTrue(mock_values.dispatch.called)
 
     @patch('collectd.Values')
+    def test_dispatch_throws_exception(self, mock_collectd_values):
+        """
+        Assert dispath throws an exception.
+        Args:
+        :param mock_collectd_values: a test object
+        """
+        mock_values = collectd.Values()
+        mock_values.dispatch = MagicMock()
+        mock_collectd_values.side_effect = Exception('Collectd exception')
+        self.collectd_plugin.dispatch_values((1, 2, 3), 'vhost', 'plugin',
+                                             'plugin_instance', 'meteric_type')
+        self.assertFalse(mock_values.dispatch.called)
+
+    @patch('collectd.Values')
     def test_dispatch_non_list(self, mock_collectd_values):
         """
         Assert that a non list value is dispatched.


### PR DESCRIPTION
When a metric is missing from the types db the plugin crushes.
In this fix I catch the exception and just notify collectd, basically ignoring the metric

what do you think?