### PR TITLE
Refactoring metric naming by not changing host or plugin, but specify…

### DIFF
--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -29,6 +29,7 @@ CONFIGS = []
 INSTANCES = []
 plugin_name = 'rabbitmq'
 
+
 def configure(config_values):
     """
     Converts a collectd configuration into rabbitmq configuration.
@@ -146,12 +147,14 @@ class CollectdPlugin(object):
             vhost_prefix = '%s_' % self.config.vhost_prefix
         return '%s%s' % (vhost_prefix, name)
 
-    def dispatch_message_stats(self, data, vhost, message_source, message_source_name):
+    def dispatch_message_stats(self, data, vhost, message_source,
+                               message_source_name):
         """
         Sends message stats to collectd.
         """
         if not data:
-            collectd.debug("No data for %s in vhost %s" % (message_source, vhost))
+            collectd.debug("No data for %s in vhost %s" %
+                           (message_source, vhost))
             return
 
         vhost = self.generate_vhost_name(vhost)
@@ -159,12 +162,15 @@ class CollectdPlugin(object):
         for name in self.message_stats:
             if 'message_stats' not in data:
                 return
-            collectd.debug("Dispatching stat %s for %s in %s" % (name, message_source_name, vhost))
+            collectd.debug("Dispatching stat %s for %s in %s" %
+                           (name, message_source_name, vhost))
 
             value = data['message_stats'].get(name, 0)
             self.dispatch_values(values=value,
                                  metric_type=name,
-                                 plugin_instance='vhost-' + vhost + '-' + message_source + '-' + message_source_name)
+                                 plugin_instance='vhost-' + vhost + '-' +
+                                                 message_source + '-' +
+                                                 message_source_name)
 
             details = data['message_stats'].get("%s_details" % name, None)
             if not details:
@@ -172,7 +178,10 @@ class CollectdPlugin(object):
             for detail in self.message_details:
                 self.dispatch_values(values=details.get(detail, 0),
                                      metric_type=name,
-                                     plugin_instance='vhost-' + vhost + '-' + message_source + '-' + message_source_name + "-details")
+                                     plugin_instance='vhost-' + vhost + '-' +
+                                                     message_source + '-' +
+                                                     message_source_name +
+                                                     "-details")
 
     def dispatch_nodes(self):
         """
@@ -193,7 +202,8 @@ class CollectdPlugin(object):
                 value = node.get(stat_name, 0)
                 self.dispatch_values(values=value,
                                      metric_type=stat_name,
-                                     plugin_instance='vhost-' + name + '-node-' + node_name)
+                                     plugin_instance='vhost-' + name +
+                                                     '-node-' + node_name)
 
                 details = node.get("%s_details" % stat_name, None)
                 if not details:
@@ -202,7 +212,9 @@ class CollectdPlugin(object):
                     value = details.get(detail, 0)
                     self.dispatch_values(values=value,
                                          metric_type="%s_details" % stat_name,
-                                         plugin_instance='vhost-' + name + '-node-' + node_name + '-details',
+                                         plugin_instance='vhost-' + name +
+                                                         '-node-' + node_name +
+                                                         '-details',
                                          type_instance=detail)
 
     def dispatch_overview(self):
@@ -230,7 +242,8 @@ class CollectdPlugin(object):
 
                 value = subtree.get(stat_name, 0)
                 self.dispatch_values(values=value,
-                                     plugin_instance='overview-' + prefixed_cluster_name,
+                                     plugin_instance='overview-' +
+                                                     prefixed_cluster_name,
                                      metric_type=type_name)
 
                 details = subtree.get("%s_details" % stat_name, None)
@@ -240,19 +253,24 @@ class CollectdPlugin(object):
                 for detail in self.message_details:
                     detail_values.append(details.get(detail, 0))
 
-                collectd.debug("Dispatching overview stat {} for {}".format(stat_name, prefixed_cluster_name))
+                collectd.debug("Dispatching overview stat {} for {}"
+                               .format(stat_name, prefixed_cluster_name))
 
                 self.dispatch_values(values=detail_values,
                                      metric_type='rabbitmq_details',
-                                     plugin_instance='overview-' + prefixed_cluster_name + '-details',
+                                     plugin_instance='overview-' +
+                                                     prefixed_cluster_name +
+                                                     '-details',
                                      type_instance=type_name)
 
-    def dispatch_queue_stats(self, data, vhost, message_source, message_source_name):
+    def dispatch_queue_stats(self, data, vhost, message_source,
+                             message_source_name):
         """
         Sends queue stats to collectd.
         """
         if not data:
-            collectd.debug("No data for %s in vhost %s" % (message_source, vhost))
+            collectd.debug("No data for %s in vhost %s" %
+                           (message_source, vhost))
             return
 
         vhost = self.generate_vhost_name(vhost)
@@ -260,11 +278,14 @@ class CollectdPlugin(object):
             if name not in data:
                 collectd.debug("Stat ({}) not found in data.".format(name))
                 continue
-            collectd.debug("Dispatching stat %s for %s in %s" % (name, message_source_name, vhost))
+            collectd.debug("Dispatching stat %s for %s in %s" %
+                           (name, message_source_name, vhost))
 
             value = data.get(name, 0)
             self.dispatch_values(values=value,
-                                 plugin_instance='vhost-' + vhost + '-' + message_source + '-' + message_source_name,
+                                 plugin_instance='vhost-' + vhost + '-' +
+                                                 message_source + '-' +
+                                                 message_source_name,
                                  metric_type=name)
 
     def dispatch_exchanges(self, vhost_name):
@@ -307,14 +328,15 @@ class CollectdPlugin(object):
         :param values (tuple or list): The values to dispatch. It will be
                                        coerced into a list.
         :param metric_type: (str):     The type of the metric.
-        :param plugin_instance (str):  Optional, overview, queues, vhost statistics
+        :param plugin_instance (str):  Optional, overview, queues,
+                                       vhost statistics
         :param type_instance (str):    Optional, type of a certain metric.
 
         """
         collectd.debug("Dispatching metric: values = %s | \
                                             metric_type = %s | \
                                             plugin_instance = %s | \
-                                            type_instance = %s" % \
+                                            type_instance = %s" %
                        (values, metric_type, plugin_instance, type_instance))
 
         try:
@@ -324,13 +346,16 @@ class CollectdPlugin(object):
             metric.plugin_instance = plugin_instance
             metric.type_instance = type_instance
             metric.values = values if utils.is_sequence(values) else [values]
-            # Tiny hack to fix bug with write_http plugin in Collectd versions < 5.5.
+            # Hack to fix bug with write_http plugin in Collectd versions < 5.5
             # See https://github.com/phobos182/collectd-elasticsearch/issues/15
             metric.meta = {'0': True}
             metric.dispatch()
         except Exception as ex:
-            collectd.warning("Failed to dispatch: values = %s | metric_type = %s | plugin_instance = %s | \
-type_instance = %s | Exception = %s" % (values, metric_type, plugin_instance, type_instance, ex))
+            collectd.warning("Failed to dispatch: values = %s | \
+                             metric_type = %s | plugin_instance = %s | \
+                             type_instance = %s | Exception = %s" %
+                             (values, metric_type, plugin_instance,
+                              type_instance, ex))
 
 # Register callbacks
 collectd.register_config(configure)

--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -201,8 +201,9 @@ class CollectdPlugin(object):
                 for detail in self.message_details:
                     value = details.get(detail, 0)
                     self.dispatch_values(values=value,
-                                         metric_type=detail,
-                                         plugin_instance='vhost-' + name + '-node-' + node_name + '-details')
+                                         metric_type="%s_details" % stat_name,
+                                         plugin_instance='vhost-' + name + '-node-' + node_name + '-details',
+                                         type_instance=detail)
 
     def dispatch_overview(self):
         """
@@ -242,8 +243,9 @@ class CollectdPlugin(object):
                 collectd.debug("Dispatching overview stat {} for {}".format(stat_name, prefixed_cluster_name))
 
                 self.dispatch_values(values=detail_values,
+                                     metric_type='rabbitmq_details',
                                      plugin_instance='overview-' + prefixed_cluster_name + '-details',
-                                     metric_type=type_name)
+                                     type_instance=type_name)
 
     def dispatch_queue_stats(self, data, vhost, message_source, message_source_name):
         """

--- a/tests/collectd.py
+++ b/tests/collectd.py
@@ -30,7 +30,7 @@ import logging
 
 class Config(object):
     """
-    Fake config oebject.
+    Fake config object.
     """
 
     def __init__(self, key, values, children=None):

--- a/tests/test_collectd_plugin.py
+++ b/tests/test_collectd_plugin.py
@@ -164,45 +164,56 @@ class TestCollectdPluginExchanges(BaseTestCollectdPlugin):
         e2_stats = get_message_stats_data('TestExchange2')['message_stats']
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            e1_stats['publish_in'], 'rabbitmq_test_vhost', 'exchanges',
-            'TestExchange1', 'publish_in'
+            values=e1_stats['publish_in'],
+            metric_type='publish_in',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange1'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            e1_stats['publish_in_details']['rate'], 'rabbitmq_test_vhost',
-            'exchanges', 'TestExchange1', 'publish_in_details', 'rate'
+            values=e1_stats['publish_in_details']['rate'],
+            metric_type='publish_in_details',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange1',
+            type_instance='rate'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            e1_stats['publish_out'], 'rabbitmq_test_vhost', 'exchanges',
-            'TestExchange1', 'publish_out'
+            values=e1_stats['publish_out'],
+            metric_type='publish_out',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange1'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            e1_stats['publish_out_details']['rate'], 'rabbitmq_test_vhost',
-            'exchanges', 'TestExchange1', 'publish_out_details', 'rate'
+            values=e1_stats['publish_out_details']['rate'],
+            metric_type='publish_out_details',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange1',
+            type_instance='rate'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            e2_stats['publish_in'], 'rabbitmq_test_vhost', 'exchanges',
-            'TestExchange2', 'publish_in'
+            values=e2_stats['publish_in'],
+            metric_type='publish_in',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange2'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            e2_stats['publish_in_details']['rate'], 'rabbitmq_test_vhost',
-            'exchanges', 'TestExchange2', 'publish_in_details', 'rate'
+            values=e2_stats['publish_in_details']['rate'],
+            metric_type='publish_in_details',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange2',
+            type_instance='rate'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            e2_stats['publish_out'], 'rabbitmq_test_vhost', 'exchanges',
-            'TestExchange2', 'publish_out'
+            values=e2_stats['publish_out'],
+            metric_type='publish_out',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange2'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            e2_stats['publish_out_details']['rate'], 'rabbitmq_test_vhost',
-            'exchanges', 'TestExchange2', 'publish_out_details', 'rate'
+            values=e2_stats['publish_out_details']['rate'],
+            metric_type='publish_out_details',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange2',
+            type_instance='rate'
         )
-
 
 class TestCollectdPluginQueues(BaseTestCollectdPlugin):
     """
@@ -233,50 +244,62 @@ class TestCollectdPluginQueues(BaseTestCollectdPlugin):
         q2_stats = get_message_stats_data('TestQueue2')['message_stats']
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            q1_stats['publish_in'], 'rabbitmq_test_vhost', 'queues',
-            'TestQueue1', 'publish_in'
+            values=q1_stats['publish_in'],
+            metric_type='publish_in',
+            plugin_instance='vhost-rabbitmq_test_vhost-queues-TestQueue1'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            q1_stats['publish_in_details']['rate'], 'rabbitmq_test_vhost',
-            'queues', 'TestQueue1', 'publish_in_details', 'rate'
+            values=q1_stats['publish_in_details']['rate'],
+            metric_type='publish_in_details',
+            plugin_instance='vhost-rabbitmq_test_vhost-queues-TestQueue1',
+            type_instance='rate'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            q1_stats['publish_out'], 'rabbitmq_test_vhost', 'queues',
-            'TestQueue1', 'publish_out'
+            values=q1_stats['publish_out'],
+            metric_type='publish_out',
+            plugin_instance='vhost-rabbitmq_test_vhost-queues-TestQueue1'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            q1_stats['publish_out_details']['rate'], 'rabbitmq_test_vhost',
-            'queues', 'TestQueue1', 'publish_out_details', 'rate'
+            values=q1_stats['publish_out_details']['rate'],
+            metric_type='publish_out_details',
+            plugin_instance='vhost-rabbitmq_test_vhost-queues-TestQueue1',
+            type_instance='rate'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            q2_stats['publish_in'], 'rabbitmq_test_vhost', 'queues',
-            'TestQueue2', 'publish_in'
+            values=q2_stats['publish_in'],
+            metric_type='publish_in',
+            plugin_instance='vhost-rabbitmq_test_vhost-queues-TestQueue2'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            q2_stats['publish_in_details']['rate'], 'rabbitmq_test_vhost',
-            'queues', 'TestQueue2', 'publish_in_details', 'rate'
+            values=q2_stats['publish_in_details']['rate'],
+            metric_type='publish_in_details',
+            plugin_instance='vhost-rabbitmq_test_vhost-queues-TestQueue2',
+            type_instance='rate'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            q2_stats['publish_out'], 'rabbitmq_test_vhost', 'queues',
-            'TestQueue2', 'publish_out'
+            values=q2_stats['publish_out'],
+            metric_type='publish_out',
+            plugin_instance='vhost-rabbitmq_test_vhost-queues-TestQueue2'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            q2_stats['publish_out_details']['rate'], 'rabbitmq_test_vhost',
-            'queues', 'TestQueue2', 'publish_out_details', 'rate'
+            values=q2_stats['publish_out_details']['rate'],
+            metric_type='publish_out_details',
+            plugin_instance='vhost-rabbitmq_test_vhost-queues-TestQueue2',
+            type_instance='rate'
         )
 
     @patch.object(collectd_plugin.rabbit.RabbitMQStats, 'get_vhosts')
     @patch('collectd_rabbitmq.rabbit.urllib2.urlopen')
     def test_dispatch_queue_stats(self, mock_urlopen, mock_vhosts):
         """
-        Assert queues are dispatched with preoper data.
+        Assert queues are dispatched with proper data.
         Args:
         :param mock_urlopen: a patched :mod:`rabbit.urllib2.urlopen` object
         :param mock_vhosts: a patched method from a :mod:`CollectdPlugin`
@@ -285,7 +308,10 @@ class TestCollectdPluginQueues(BaseTestCollectdPlugin):
         mock_queue_stats = dict(messages=10)
         self.collectd_plugin.dispatch_values = mock_dispatch
         self.collectd_plugin.dispatch_queue_stats(
-            mock_queue_stats, 'test_vhost', None, None)
+            data=mock_queue_stats,
+            vhost='test_vhost',
+            message_source='queues',
+            message_source_name='TestQueue')
 
         self.assertTrue(mock_dispatch.called)
 
@@ -302,7 +328,10 @@ class TestCollectdPluginQueues(BaseTestCollectdPlugin):
         self.collectd_plugin.dispatch_values = mock_dispatch
 
         self.collectd_plugin.dispatch_queue_stats(
-            None, 'test_vhost', None, None)
+            data=None,
+            vhost='test_vhost',
+            message_source='queues',
+            message_source_name='TestQueue')
 
         self.assertFalse(mock_dispatch.called)
 
@@ -331,7 +360,7 @@ class TestCollectdPluginOverviewStats(BaseTestCollectdPlugin):
         self.collectd_plugin.dispatch_values = mock_dispatch
         self.collectd_plugin.dispatch_overview()
 
-        # Calculate the proper nubmer of dispatches without dispatching details
+        # Calculate the proper number of dispatches without dispatching details
         dispatches = sum(len(v) for v in self.collectd_plugin.overview_stats)
 
         self.assertTrue(mock_dispatch.call_count < dispatches)
@@ -359,7 +388,7 @@ class TestCollectdPluginOverviewStats(BaseTestCollectdPlugin):
         self.collectd_plugin.dispatch_values = mock_dispatch
         self.collectd_plugin.dispatch_overview()
 
-        # Calculate the proper nubmer of dispatches without dispatching details
+        # Calculate the proper number of dispatches without dispatching details
         dispatches = sum(len(v) for v in self.collectd_plugin.overview_stats)
 
         self.assertTrue(mock_dispatch.call_count < dispatches)
@@ -369,7 +398,7 @@ class TestCollectdPluginOverviewStats(BaseTestCollectdPlugin):
     def test_overview_stats_details(self, mock_urlopen, mock_vhosts):
         """
         Assert overview stats are dispatched with even if there are no details.
-        This work by manking sure that only the default data is dispatched.
+        This work by making sure that only the default data is dispatched.
 
         Args:
         :param mock_urlopen: a patched :mod:`rabbit.urllib2.urlopen` object
@@ -385,7 +414,7 @@ class TestCollectdPluginOverviewStats(BaseTestCollectdPlugin):
         self.collectd_plugin.dispatch_values = mock_dispatch
         self.collectd_plugin.dispatch_overview()
 
-        # Calculate the proper nubmer of default dispatches
+        # Calculate the proper number of default dispatches
         dispatches = sum(len(v) for v in self.collectd_plugin.overview_stats)
         # Add 1 for our detailed dispatch
         dispatches = dispatches + 1
@@ -398,7 +427,7 @@ class TestCollectdPluginOverviewStats(BaseTestCollectdPlugin):
                                                     mock_vhosts):
         """
         Assert overview stats without cluster_name are dispatched.
-        This work by manking sure that only the default data is dispatched.
+        This work by making sure that only the default data is dispatched.
 
         Args:
         :param mock_urlopen: a patched :mod:`rabbit.urllib2.urlopen` object
@@ -413,7 +442,7 @@ class TestCollectdPluginOverviewStats(BaseTestCollectdPlugin):
         self.collectd_plugin.dispatch_values = mock_dispatch
         self.collectd_plugin.dispatch_overview()
 
-        # Calculate the proper nubmer of default dispatches
+        # Calculate the proper number of default dispatches
         dispatches = sum(len(v) for v in self.collectd_plugin.overview_stats)
         # Add 1 for our detailed dispatch
         dispatches = dispatches + 1
@@ -446,35 +475,35 @@ class TestCollectdPluginVhost(BaseTestCollectdPlugin):
         Assert empty vhost is set properly.
         """
         vhost = self.collectd_plugin.generate_vhost_name(None)
-        self.assertEquals(vhost, "rabbitmq_default")
+        self.assertEquals(vhost, "default")
 
     def test_generate_vhost_default(self):
         """
         Assert default vhost is set properly.
         """
         vhost = self.collectd_plugin.generate_vhost_name("/")
-        self.assertEquals(vhost, "rabbitmq_default")
+        self.assertEquals(vhost, "default")
 
     def test_generate_vhost_start_slash(self):
         """
         Assert vhost that starts with a '/' is set properly.
         """
         vhost = self.collectd_plugin.generate_vhost_name("/vhost")
-        self.assertEquals(vhost, "rabbitmq_slash_vhost")
+        self.assertEquals(vhost, "slash_vhost")
 
     def test_generate_vhost_end_slash(self):
         """
         Assert vhost that ends with a '/' is set properly.
         """
         vhost = self.collectd_plugin.generate_vhost_name("vhost/")
-        self.assertEquals(vhost, "rabbitmq_vhost_slash")
+        self.assertEquals(vhost, "vhost_slash")
 
     def test_generate_vhost(self):
         """
         Assert vhost that contains a slash is set properly.
         """
         vhost = self.collectd_plugin.generate_vhost_name("vho/st")
-        self.assertEquals(vhost, "rabbitmq_vho_slash_st")
+        self.assertEquals(vhost, "vho_slash_st")
 
     def test_generate_vhost_prefix(self):
         """
@@ -482,7 +511,7 @@ class TestCollectdPluginVhost(BaseTestCollectdPlugin):
         """
         self.collectd_plugin.config.vhost_prefix = 'test_prefix'
         vhost = self.collectd_plugin.generate_vhost_name("vhost")
-        self.assertEquals(vhost, "rabbitmq_test_prefix_vhost")
+        self.assertEquals(vhost, "test_prefix_vhost")
         self.collectd_plugin.config.vhost_prefix = ''
 
 
@@ -572,23 +601,31 @@ class TestCollectdPluginDispatch(BaseTestCollectdPlugin):
         mock_values = collectd.Values()
         mock_values.dispatch = MagicMock()
         mock_collectd_values.return_value = mock_values
-        self.collectd_plugin.dispatch_values((1, 2, 3), 'vhost', 'plugin',
-                                             'plugin_instance', 'meteric_type')
+        self.collectd_plugin.dispatch_values(
+            values=(1, 2, 3),
+            metric_type='metric_type',
+            plugin_instance='plugin_instance',
+            type_instance='type_instance'
+        )
         self.assertEqual(mock_values.host, "vhost")
         self.assertTrue(mock_values.dispatch.called)
 
     @patch('collectd.Values')
     def test_dispatch_throws_exception(self, mock_collectd_values):
         """
-        Assert dispath throws an exception.
+        Assert dispatch throws an exception.
         Args:
         :param mock_collectd_values: a test object
         """
         mock_values = collectd.Values()
         mock_values.dispatch = MagicMock()
         mock_collectd_values.side_effect = Exception('Collectd exception')
-        self.collectd_plugin.dispatch_values((1, 2, 3), 'vhost', 'plugin',
-                                             'plugin_instance', 'meteric_type')
+        self.collectd_plugin.dispatch_values(
+            values=(1, 2, 3),
+            metric_type='metric_type',
+            plugin_instance='plugin_instance',
+            type_instance='type_instance'
+        )
         self.assertFalse(mock_values.dispatch.called)
 
     @patch('collectd.Values')
@@ -601,8 +638,12 @@ class TestCollectdPluginDispatch(BaseTestCollectdPlugin):
         mock_values = collectd.Values()
         mock_values.dispatch = MagicMock()
         mock_collectd_values.return_value = mock_values
-        self.collectd_plugin.dispatch_values('test_value', 'vhost', 'plugin',
-                                             'plugin_instance', 'meteric_type')
+        self.collectd_plugin.dispatch_values(
+            values='test_value',
+            metric_type='metric_type',
+            plugin_instance='plugin_instance',
+            type_instance='type_instance'
+        )
         self.assertEqual(mock_values.host, "vhost")
         self.assertTrue(mock_values.dispatch.called)
 
@@ -615,22 +656,29 @@ class TestCollectdPluginDispatch(BaseTestCollectdPlugin):
         """
         mock_values = collectd.Values()
         mock_collectd_values.return_value = mock_values
-        self.collectd_plugin.dispatch_values((1, 2, 3), '/', 'plugin',
-                                             'plugin_instance', 'meteric_type')
+        self.collectd_plugin.dispatch_values(
+            values=(1, 2, 3),
+            metric_type='metric_type',
+            plugin_instance='plugin_instance',
+            type_instance='type_instance'
+        )
         self.assertEqual(mock_values.meta, {'0': True})
 
     @patch('collectd.Values')
     def test_dispatch_type_instance(self, mock_collectd_values):
         """
-        Assert type_instance get set and dispatched.
+        Assert type_instance gets set and dispatched.
         Args:
         :param mock_collectd_values: a test object
         """
         mock_values = collectd.Values()
         mock_collectd_values.return_value = mock_values
-        self.collectd_plugin.dispatch_values((1, 2, 3), '/', 'plugin',
-                                             'plugin_instance', 'meteric_type',
-                                             'type_instance')
+        self.collectd_plugin.dispatch_values(
+            values=(1, 2, 3),
+            metric_type='metric_type',
+            plugin_instance='plugin_instance',
+            type_instance='type_instance'
+        )
         self.assertEqual(mock_values.type_instance, "type_instance")
 
 
@@ -644,9 +692,12 @@ class TestCollectdPluginDispatchMessageStats(BaseTestCollectdPlugin):
         Assert that empty data is not dispatched.
         """
         self.collectd_plugin.dispatch_values = Mock()
-        self.collectd_plugin.dispatch_message_stats(None, 'test_vhost',
-                                                    'test_plugin',
-                                                    'type_plugin_instance')
+        self.collectd_plugin.dispatch_message_stats(
+            data=None,
+            vhost='test_vhost',
+            message_source='queues',
+            message_source_name='TestQueue'
+        )
         self.assertFalse(self.collectd_plugin.dispatch_values.called)
 
     def test_dispatch_no_message_stats(self):
@@ -654,10 +705,12 @@ class TestCollectdPluginDispatchMessageStats(BaseTestCollectdPlugin):
         Assert that data without message_stats are not dispatched.
         """
         self.collectd_plugin.dispatch_values = Mock()
-        self.collectd_plugin.dispatch_message_stats(dict(test=Mock),
-                                                    'test_vhost',
-                                                    'test_plugin',
-                                                    'type_plugin_instance')
+        self.collectd_plugin.dispatch_message_stats(
+            data=dict(test=Mock),
+            vhost='test_vhost',
+            message_source='queues',
+            message_source_name='TestQueue'
+        )
         self.assertFalse(self.collectd_plugin.dispatch_values.called)
 
 if __name__ == '__main__':

--- a/tests/test_collectd_plugin.py
+++ b/tests/test_collectd_plugin.py
@@ -164,9 +164,9 @@ class TestCollectdPluginExchanges(BaseTestCollectdPlugin):
         e2_stats = get_message_stats_data('TestExchange2')['message_stats']
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            values=e1_stats['publish_in'],
-            metric_type='publish_in',
-            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange1'
+            e1_stats['publish_in'],
+            'publish_in',
+            'vhost-rabbitmq_test_vhost-exchanges-TestExchange1'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
@@ -607,7 +607,6 @@ class TestCollectdPluginDispatch(BaseTestCollectdPlugin):
             plugin_instance='plugin_instance',
             type_instance='type_instance'
         )
-        self.assertEqual(mock_values.host, "vhost")
         self.assertTrue(mock_values.dispatch.called)
 
     @patch('collectd.Values')
@@ -644,7 +643,6 @@ class TestCollectdPluginDispatch(BaseTestCollectdPlugin):
             plugin_instance='plugin_instance',
             type_instance='type_instance'
         )
-        self.assertEqual(mock_values.host, "vhost")
         self.assertTrue(mock_values.dispatch.called)
 
     @patch('collectd.Values')

--- a/tests/test_collectd_plugin.py
+++ b/tests/test_collectd_plugin.py
@@ -166,7 +166,9 @@ class TestCollectdPluginExchanges(BaseTestCollectdPlugin):
         self.collectd_plugin.dispatch_values.assert_any_call(
             values=e1_stats['publish_in'],
             metric_type='publish_in',
-            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange1'
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-\
+                            TestExchange1',
+            type_instance=''
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
@@ -180,7 +182,9 @@ class TestCollectdPluginExchanges(BaseTestCollectdPlugin):
         self.collectd_plugin.dispatch_values.assert_any_call(
             values=e1_stats['publish_out'],
             metric_type='publish_out',
-            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange1'
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-\
+                            TestExchange1',
+            type_instance=''
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(

--- a/tests/test_collectd_plugin.py
+++ b/tests/test_collectd_plugin.py
@@ -158,21 +158,22 @@ class TestCollectdPluginExchanges(BaseTestCollectdPlugin):
         mock_vhosts.return_value = [dict(name='test_vhost')]
 
         self.collectd_plugin.dispatch_values = MagicMock()
-        self.collectd_plugin.dispatch_exchanges('test_vhost')
+        self.collectd_plugin.dispatch_exchanges(vhost_name='test_vhost')
 
         e1_stats = get_message_stats_data('TestExchange1')['message_stats']
         e2_stats = get_message_stats_data('TestExchange2')['message_stats']
 
         self.collectd_plugin.dispatch_values.assert_any_call(
-            e1_stats['publish_in'],
-            'publish_in',
-            'vhost-rabbitmq_test_vhost-exchanges-TestExchange1'
+            values=e1_stats['publish_in'],
+            metric_type='publish_in',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange1'
         )
 
         self.collectd_plugin.dispatch_values.assert_any_call(
             values=e1_stats['publish_in_details']['rate'],
             metric_type='publish_in_details',
-            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange1',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-\
+                            TestExchange1',
             type_instance='rate'
         )
 
@@ -185,7 +186,8 @@ class TestCollectdPluginExchanges(BaseTestCollectdPlugin):
         self.collectd_plugin.dispatch_values.assert_any_call(
             values=e1_stats['publish_out_details']['rate'],
             metric_type='publish_out_details',
-            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange1',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-\
+                            TestExchange1',
             type_instance='rate'
         )
 
@@ -198,7 +200,8 @@ class TestCollectdPluginExchanges(BaseTestCollectdPlugin):
         self.collectd_plugin.dispatch_values.assert_any_call(
             values=e2_stats['publish_in_details']['rate'],
             metric_type='publish_in_details',
-            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange2',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-\
+                            TestExchange2',
             type_instance='rate'
         )
 
@@ -211,9 +214,11 @@ class TestCollectdPluginExchanges(BaseTestCollectdPlugin):
         self.collectd_plugin.dispatch_values.assert_any_call(
             values=e2_stats['publish_out_details']['rate'],
             metric_type='publish_out_details',
-            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-TestExchange2',
+            plugin_instance='vhost-rabbitmq_test_vhost-exchanges-\
+                            TestExchange2',
             type_instance='rate'
         )
+
 
 class TestCollectdPluginQueues(BaseTestCollectdPlugin):
     """


### PR DESCRIPTION
This will rename metrics so they will stay at the same host and only plugin-instance and type-instance can be overwritten.
From looking at other python plugins and for example the GenericJMX plugin, the metric would always be prefixed with the plugin name, but the host was never changed.

The metrics now look like this:
```
drwxr-xr-x 2 graphite graphite 4096 Jun 12 16:05 rabbitmq-overview-cluster_rabbit_at_minion3_example_com
drwxr-xr-x 2 graphite graphite 4096 Jun 12 13:54 rabbitmq-vhost-default-exchanges-hexchange
drwxr-xr-x 2 graphite graphite   27 Jun 12 13:54 rabbitmq-vhost-default-exchanges-hexchange-details
drwxr-xr-x 2 graphite graphite 4096 Jun 12 00:30 rabbitmq-vhost-default-queues-hello
drwxr-xr-x 2 graphite graphite   24 Jun 12 00:30 rabbitmq-vhost-default-queues-hello-details
```

```
rabbitmq-overview-cluster_rabbit_at_minion3_example_com:
total 15300
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 ack.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 confirm.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 deliver_get.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 deliver_noack.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 deliver.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 publish.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 rabbitmq_channels.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 rabbitmq_connections.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 rabbitmq_consumers.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 rabbitmq_exchanges.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 rabbitmq_messages_ready.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 rabbitmq_messages_unacknowledged.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 rabbitmq_messages.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 rabbitmq_queues.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 redeliver.wsp

rabbitmq-vhost-default-exchanges-hexchange:
total 12240
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 ack.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 confirm.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 deliver_get.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 deliver_noack.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 deliver.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 get_noack.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 get.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 publish_in.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 publish_out.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 publish.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 redeliver.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 return.wsp

rabbitmq-vhost-default-exchanges-hexchange-details:
total 1020
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 publish_in.wsp

rabbitmq-vhost-default-queues-hello:
total 16384
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 ack.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 confirm.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 consumers.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 deliver_get.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 deliver_noack.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 deliver.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 get_noack.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 get.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 messages_ready.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 messages_unacknowledged.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 messages.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 publish_in.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 publish_out.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 publish.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 redeliver.wsp
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 return.wsp

rabbitmq-vhost-default-queues-hello-details:
total 1024
-rw-r--r-- 1 graphite graphite 1041184 Jun 12 16:18 publish.wsp
```

Yes, this is a breaking change unfortunately. May be there is a way to keep backward compatibility?