### PR TITLE
Optional collection of node stats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ This plugin supports a small amount of configuration options:
 * `Host`: The hostname that the rabbitmq server running on. Defaults to `localhost`
 * `Port`: The port that the rabbitmq server is listening on. Defaults to `15672`
 * `VHostPrefix`: Arbitrary string to prefix the vhost name with. Defaults to None
+* `CollectNodeStats`: Collect system stats for the node or not if set to False. Defaults to True
 * `Ignore`: The queue to ignore, matching by Regex.  See example.
 
 See `this example`_ for further details.

--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -38,6 +38,7 @@ def configure(config_values):
     data_to_ignore = dict()
     scheme = 'http'
     vhost_prefix = None
+    node_stats = True
 
     for config_value in config_values.children:
         collectd.debug("%s = %s" % (config_value.key, config_value.values))
@@ -56,6 +57,8 @@ def configure(config_values):
                 scheme = config_value.values[0]
             elif config_value.key == 'VHostPrefix':
                 vhost_prefix = config_value.values[0]
+            elif config_value.key == 'CollectNodeStats':
+                node_stats = config_value.values[0]
             elif config_value.key == 'Ignore':
                 type_rmq = config_value.values[0]
                 data_to_ignore[type_rmq] = list()
@@ -66,7 +69,7 @@ def configure(config_values):
 
     auth = utils.Auth(username, password, realm)
     conn = utils.ConnectionInfo(host, port, scheme)
-    config = utils.Config(auth, conn, data_to_ignore, vhost_prefix)
+    config = utils.Config(auth, conn, data_to_ignore, vhost_prefix, node_stats)
     CONFIGS.append(config)
 
 
@@ -121,7 +124,8 @@ class CollectdPlugin(object):
         """
         Dispatches values to collectd.
         """
-        self.dispatch_nodes()
+        if self.config.node_stats:
+            self.dispatch_nodes()
         self.dispatch_overview()
         for vhost_name in self.rabbit.vhost_names:
             self.dispatch_exchanges(vhost_name)

--- a/collectd_rabbitmq/utils.py
+++ b/collectd_rabbitmq/utils.py
@@ -65,11 +65,12 @@ class Config(object):
     """
 
     def __init__(self, auth, connection, data_to_ignore=None,
-                 vhost_prefix=None):
+                 vhost_prefix=None, node_stats=True):
         self.auth = auth
         self.connection = connection
         self.data_to_ignore = dict()
         self.vhost_prefix = vhost_prefix
+        self.node_stats = node_stats
 
         if data_to_ignore:
             for key, values in data_to_ignore.items():


### PR DESCRIPTION
I thought for whoever is already collecting the node statistics with other collectd plugins like "memory", "disk" or "cpu" it might be helpful to turn off the collection of those.
The default would still be to collect node stats.

Fixed commit message from previous pull request which was failing integration tests.