### PR TITLE
skip data collection on / vhost to address issue #32

### DIFF
--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -124,6 +124,9 @@ class CollectdPlugin(object):
         self.dispatch_nodes()
         self.dispatch_overview()
         for vhost_name in self.rabbit.vhost_names:
+            # skip vhost name /
+            if vhost_name == "%2F":
+                continue
             self.dispatch_exchanges(vhost_name)
             self.dispatch_queues(vhost_name)
 


### PR DESCRIPTION
This may not be a good candidate to merge, but it does resolve issue #32 401 returned when using plugin - even though standard Basic Auth curls work using creds, so hopefully at least contributes to a better and less hacky solution.