### PR TITLE
Include additional metric consumer_utilisation in the queue_stats function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,7 @@ _NOTE_: The `/` vhost name is sent as `default`
   * rate
 * memory
 * consumers
+* consumer_utilisation
 
 Exchanges
 ----------

--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -102,8 +102,8 @@ class CollectdPlugin(object):
                      'deliver', 'deliver_noack', 'get', 'get_noack',
                      'deliver_get', 'redeliver', 'return']
     message_details = ['avg', 'avg_rate', 'rate', 'sample']
-    queue_stats = ['consumers', 'messages', 'messages_ready',
-                   'messages_unacknowledged']
+    queue_stats = ['consumers', 'consumer_utilisation', 'messages',
+                   'messages_ready', 'messages_unacknowledged']
     node_stats = ['disk_free', 'disk_free_limit', 'fd_total',
                   'fd_used', 'mem_limit', 'mem_used',
                   'proc_total', 'proc_used', 'processors', 'run_queue',
@@ -259,8 +259,10 @@ class CollectdPlugin(object):
                 continue
             collectd.debug("Dispatching stat %s for %s in %s" %
                            (name, plugin_instance, vhost))
-
             value = data.get(name, 0)
+            if name is 'consumer_utilisation':
+                if value is None:
+                    value = 0
             self.dispatch_values(value, vhost, plugin, plugin_instance, name)
 
     def dispatch_exchanges(self, vhost_name):

--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -22,6 +22,7 @@ rabbitmq_messages_ready          value:GAUGE:0:U
 rabbitmq_messages_unacknowledged value:GAUGE:0:U
 rabbitmq_connections             value:GAUGE:0:U
 rabbitmq_consumers               value:GAUGE:0:U
+rabbitmq_consumer_utilisation    value:GAUGE:0:1
 rabbitmq_exchanges               value:GAUGE:0:U
 rabbitmq_channels                value:GAUGE:0:U
 rabbitmq_queues                  value:GAUGE:0:U
@@ -51,6 +52,7 @@ redeliver_details       value:GAUGE:0:U
 return                  value:GAUGE:0:U
 
 consumers               value:GAUGE:0:U
+consumer_utilisation    value:GAUGE:0:1
 messages                value:GAUGE:0:U
 messages_ready          value:GAUGE:0:U
 messages_unacknowledged value:GAUGE:0:U

--- a/tests/test_collectd_plugin.py
+++ b/tests/test_collectd_plugin.py
@@ -293,6 +293,24 @@ class TestCollectdPluginQueues(BaseTestCollectdPlugin):
 
     @patch.object(collectd_plugin.rabbit.RabbitMQStats, 'get_vhosts')
     @patch('collectd_rabbitmq.rabbit.urllib2.urlopen')
+    def test_dispatch_queue_stats_consumer_utilisation(
+      self, mock_urlopen, mock_vhosts):
+        """
+        Assert queues are dispatched with preoper data.
+        Args:
+        :param mock_urlopen: a patched :mod:`rabbit.urllib2.urlopen` object
+        :param mock_vhosts: a patched method from a :mod:`CollectdPlugin`
+        """
+        mock_dispatch = MagicMock()
+        mock_queue_stats = dict(consumer_utilisation=None)
+        self.collectd_plugin.dispatch_values = mock_dispatch
+        self.collectd_plugin.dispatch_queue_stats(
+            mock_queue_stats, 'test_vhost', None, None)
+
+        self.assertTrue(mock_dispatch.called)
+
+    @patch.object(collectd_plugin.rabbit.RabbitMQStats, 'get_vhosts')
+    @patch('collectd_rabbitmq.rabbit.urllib2.urlopen')
     def test_dispatch_empty_queue_stats(self, mock_urlopen, mock_vhosts):
         """
         Assert queues are not dispatched with no data.


### PR DESCRIPTION
As mentioned incoporated a new metric to the queue_stats function in order to report on the consumer_utilisation. This provides the ability to monitor consumer utilisation. Resulting in an early indication of issues with the queue and highlighting slow message delivery.

- [X] Existing tests pass
- [X] New Test Added
- [X] Updated the README