### PR TITLE
Add 'LocalQueuesOnly' option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ This plugin supports a small amount of configuration options:
 * `ValidateCerts`: You can ignore verifying the SSL certificate if you set it to `false`. Defaults to `true`
 * `VHostPrefix`: Arbitrary string to prefix the vhost name with. Defaults to None
 * `Ignore`: The queue to ignore, matching by Regex.  See example.
+* `LocalQueuesOnly`: For clustered rabbitmq nodes report only queues resident on the node being queried. Defaults to `false`
 
 See `this example`_ for further details.
     .. _this example: config/collectd.conf

--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -39,6 +39,7 @@ def configure(config_values):
     scheme = 'http'
     validate_certs = True
     vhost_prefix = None
+    local_queues_only = False
 
     for config_value in config_values.children:
         collectd.debug("%s = %s" % (config_value.key, config_value.values))
@@ -59,6 +60,8 @@ def configure(config_values):
                 vhost_prefix = config_value.values[0]
             elif config_value.key == 'ValidateCerts':
                 validate_certs = config_value.values[0]
+            elif config_value.key == 'LocalQueuesOnly':
+                local_queues_only = config_value.values[0]
             elif config_value.key == 'Ignore':
                 type_rmq = config_value.values[0]
                 data_to_ignore[type_rmq] = list()
@@ -70,7 +73,7 @@ def configure(config_values):
     auth = utils.Auth(username, password, realm)
     conn = utils.ConnectionInfo(host, port, scheme,
                                 validate_certs=validate_certs)
-    config = utils.Config(auth, conn, data_to_ignore, vhost_prefix)
+    config = utils.Config(auth, conn, data_to_ignore, vhost_prefix, local_queues_only)
     CONFIGS.append(config)
 
 

--- a/collectd_rabbitmq/rabbit.py
+++ b/collectd_rabbitmq/rabbit.py
@@ -150,8 +150,13 @@ class RabbitMQStats(object):
         """
         Returns raw queue data.
         """
-        collectd.debug("Getting queues for %s" % vhost_name)
-        return self.get_info("queues", vhost_name)
+        if self.config.local_queues_only == True:
+            node = self.get_info("overview")["node"]
+            collectd.debug("Getting local queues for %s:%s" % (node, vhost_name))
+            return [x for x in self.get_info("queues", vhost_name) if x["node"] == node]
+        else:
+            collectd.debug("Getting queues for %s" % vhost_name)
+            return self.get_info("queues", vhost_name)
 
     def get_queue_names(self, vhost_name=None):
         """

--- a/collectd_rabbitmq/utils.py
+++ b/collectd_rabbitmq/utils.py
@@ -67,11 +67,12 @@ class Config(object):
     """
 
     def __init__(self, auth, connection, data_to_ignore=None,
-                 vhost_prefix=None):
+                 vhost_prefix=None, local_queues_only=False):
         self.auth = auth
         self.connection = connection
         self.data_to_ignore = dict()
         self.vhost_prefix = vhost_prefix
+        self.local_queues_only = local_queues_only
 
         if data_to_ignore:
             for key, values in data_to_ignore.items():


### PR DESCRIPTION
Our monitoring workflow relies on cluster nodes reporting their own stats to the backend, so I've added an option that causes `get_queues()` to return only queues that are local to the node being queried.