### PR TITLE
Don't collect some always-empty values, don't dispatch empty values

### DIFF
--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -166,15 +166,22 @@ class CollectdPlugin(object):
             collectd.debug("Dispatching stat %s for %s in %s" %
                            (name, plugin_instance, vhost))
 
-            value = data['message_stats'].get(name, 0)
+            try:
+                value = data['message_stats'][name]
+            except KeyError:
+                continue
             self.dispatch_values(value, vhost, plugin, plugin_instance, name)
 
             details = data['message_stats'].get("%s_details" % name, None)
             if not details:
                 continue
             for detail in self.message_details:
+                try:
+                    value = details[detail]
+                except KeyError:
+                    continue
                 self.dispatch_values(
-                    (details.get(detail, 0)), vhost, plugin, plugin_instance,
+                    value, vhost, plugin, plugin_instance,
                     "%s_details" % name, detail)
 
     def dispatch_nodes(self):
@@ -193,14 +200,20 @@ class CollectdPlugin(object):
             node_names.append(node_name)
             collectd.debug("Getting stats for %s node" % node_names)
             for stat_name in self.node_stats:
-                value = node.get(stat_name, 0)
+                try:
+                    value = node[stat_name]
+                except KeyError:
+                    continue
                 self.dispatch_values(value, name, node_name, None, stat_name)
 
                 details = node.get("%s_details" % stat_name, None)
                 if not details:
                     continue
                 for detail in self.message_details:
-                    value = details.get(detail, 0)
+                    try:
+                        value = details[detail]
+                    except KeyError:
+                        continue
                     self.dispatch_values(value, name, node_name, None,
                                          "%s_details" % stat_name, detail)
 
@@ -226,7 +239,10 @@ class CollectdPlugin(object):
                 if re.match(stats_re, stat_name) is not None:
                     type_name = "rabbitmq_%s" % stat_name
 
-                value = subtree.get(stat_name, 0)
+                try:
+                    value = subtree[stat_name]
+                except KeyError:
+                    continue
                 self.dispatch_values(value, prefixed_cluster_name, "overview",
                                      subtree_name, type_name)
 
@@ -235,6 +251,9 @@ class CollectdPlugin(object):
                     continue
                 detail_values = []
                 for detail in self.message_details:
+                    # The length of detail_values list needs to match the
+                    # length of the declaration in types.db, so we pad with
+                    # zeros.
                     detail_values.append(details.get(detail, 0))
 
                 collectd.debug("Dispatching overview stat {} for {}".format(
@@ -259,7 +278,10 @@ class CollectdPlugin(object):
                 continue
             collectd.debug("Dispatching stat %s for %s in %s" %
                            (name, plugin_instance, vhost))
-            value = data.get(name, 0)
+            try:
+                value = data[name]
+            except KeyError:
+                continue
             if name is 'consumer_utilisation':
                 if value is None:
                     value = 0

--- a/collectd_rabbitmq/collectd_plugin.py
+++ b/collectd_rabbitmq/collectd_plugin.py
@@ -101,7 +101,7 @@ class CollectdPlugin(object):
     message_stats = ['ack', 'publish', 'publish_in', 'publish_out', 'confirm',
                      'deliver', 'deliver_noack', 'get', 'get_noack',
                      'deliver_get', 'redeliver', 'return']
-    message_details = ['avg', 'avg_rate', 'rate', 'sample']
+    message_details = ['rate']
     queue_stats = ['consumers', 'consumer_utilisation', 'messages',
                    'messages_ready', 'messages_unacknowledged']
     node_stats = ['disk_free', 'disk_free_limit', 'fd_total',

--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -26,7 +26,7 @@ rabbitmq_consumer_utilisation    value:GAUGE:0:1
 rabbitmq_exchanges               value:GAUGE:0:U
 rabbitmq_channels                value:GAUGE:0:U
 rabbitmq_queues                  value:GAUGE:0:U
-rabbitmq_details                 avg:GAUGE:0:U avg_rate:GAUGE:0:U rate:GAUGE:0:U samples:GAUGE:0:U
+rabbitmq_details                 rate:GAUGE:0:U
 
 ack                 value:GAUGE:0:U
 ack_details         value:GAUGE:0:U


### PR DESCRIPTION
This fixes #72 , see the issue for details. The two problems outlined in issue #72 are fixed by two different commits in this PR.