### PR TITLE
Don't return None for methods that should return lists

### DIFF
--- a/collectd_rabbitmq/rabbit.py
+++ b/collectd_rabbitmq/rabbit.py
@@ -126,7 +126,7 @@ class RabbitMQStats(object):
         Returns raw exchange data.
         """
         collectd.debug("Getting exchanges for %s" % vhost_name)
-        return self.get_info("exchanges", vhost_name)
+        return self.get_info("exchanges", vhost_name) or list()
 
     def get_exchange_names(self, vhost_name=None):
         """
@@ -151,7 +151,7 @@ class RabbitMQStats(object):
         Returns raw queue data.
         """
         collectd.debug("Getting queues for %s" % vhost_name)
-        return self.get_info("queues", vhost_name)
+        return self.get_info("queues", vhost_name) or list()
 
     def get_queue_names(self, vhost_name=None):
         """

--- a/tests/test_rabbit.py
+++ b/tests/test_rabbit.py
@@ -377,6 +377,20 @@ class TestIgnoredQueues(TestStatsBaseClass):
         exchanges = self.stats.get_exchanges("test_vhost")
         self.assertIsNotNone(exchanges)
 
+    @patch('collectd_rabbitmq.rabbit.urllib2.urlopen')
+    def test_get_exchanges_unavailable(self, mock_urlopen):
+        """
+        Asserts that get_exchanges returns an empty list if it can't access the
+        data.
+
+        Args:
+        :param mock_urlopen: A patched urllib object
+        """
+        mock_urlopen.side_effect = urllib2.HTTPError(
+            "testurl", 401, "Forbidden", None, None)
+        exchanges = self.stats.get_exchanges("test_vhost")
+        self.assertEqual(exchanges, [])
+
 
 class TestIgnoredExchanges(TestStatsBaseClass):
     """
@@ -446,6 +460,20 @@ class TestIgnoredExchanges(TestStatsBaseClass):
         mock_urlopen.side_effect = create_mock_url_repsonse
         queues = self.stats.get_queues("test_vhost")
         self.assertIsNotNone(queues)
+
+    @patch('collectd_rabbitmq.rabbit.urllib2.urlopen')
+    def test_get_queue_unavailable(self, mock_urlopen):
+        """
+        Asserts that get_queues returns an empty list if it can't access the
+        data.
+
+        Args:
+        :param mock_urlopen: A patched urllib object
+        """
+        mock_urlopen.side_effect = urllib2.HTTPError(
+            "testurl", 401, "Forbidden", None, None)
+        queues = self.stats.get_queues("test_vhost")
+        self.assertEqual(queues, [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some methods are expected to return lists, however if the virtualhost is
unavailable because of restricted permissions on the connecting user,
they will return None and crash the plugin.

Fixes #68

Signed-off-by: Aurélien Bompard <aurelien@bompard.org>